### PR TITLE
New get, "show", and verbosity features.

### DIFF
--- a/src/bri_get.c
+++ b/src/bri_get.c
@@ -120,7 +120,6 @@ int bam_read_idx_get_main(int argc, char** argv)
     }
 
     char* input_bam = argv[optind++];
-    char* readname = argv[optind++];
 
     bam_read_idx* bri = bam_read_idx_load(input_bam, input_bri);
     
@@ -131,21 +130,24 @@ int bam_read_idx_get_main(int argc, char** argv)
     bam_read_idx_record* start;
     bam_read_idx_record* end;
 
-    bam_read_idx_get_range(bri, readname, &start, &end);
-    bam1_t* b = bam_init1();
-    while(start != end) {
-        
-        bam_read_idx_get_by_record(bam_fp, h, b, start);
-        int ret = sam_write1(out_fp, h, b);
-        if(ret < 0) {
-            fprintf(stderr, "[bri] sam_write1 failed\n");
-            exit(EXIT_FAILURE);
-        }
+    for(int i = optind; i < argc; i++) {
+        char* readname = argv[i];
+        bam_read_idx_get_range(bri, readname, &start, &end);
+        bam1_t* b = bam_init1();
+        while(start != end) {
+            
+            bam_read_idx_get_by_record(bam_fp, h, b, start);
+            int ret = sam_write1(out_fp, h, b);
+            if(ret < 0) {
+                fprintf(stderr, "[bri] sam_write1 failed\n");
+                exit(EXIT_FAILURE);
+            }
 
-        start++;
+            start++;
+        }
+        bam_destroy1(b);
     }
 
-    bam_destroy1(b);
     hts_close(out_fp);
     bam_hdr_destroy(h);
     hts_close(bam_fp);

--- a/src/bri_get.c
+++ b/src/bri_get.c
@@ -20,15 +20,16 @@ enum {
     OPT_HELP = 1,
 };
 
-static const char* shortopts = ""; // placeholder
+static const char* shortopts = ":i:"; // placeholder
 static const struct option longopts[] = {
     { "help",                      no_argument,       NULL, OPT_HELP },
+    { "index",               required_argument,       NULL,      'i' },
     { NULL, 0, NULL, 0 }
 };
 
 void print_usage_get()
 {
-    fprintf(stderr, "usage: bri get <input.bam> <readname>\n");
+    fprintf(stderr, "usage: bri get [-i <index_filename.bri>] <input.bam> <readname>\n");
 }
 
 // comparator used by bsearch, direct strcmp through the name pointer
@@ -95,12 +96,16 @@ void bam_read_idx_get_by_record(htsFile* fp, bam_hdr_t* hdr, bam1_t* b, bam_read
 //
 int bam_read_idx_get_main(int argc, char** argv)
 {
+    char* input_bri = NULL;
+
     int die = 0;
     for (char c; (c = getopt_long(argc, argv, shortopts, longopts, NULL)) != -1;) {
         switch (c) {
             case OPT_HELP:
                 print_usage_get();
                 exit(EXIT_SUCCESS);
+            case 'i':
+                input_bri = optarg;
         }
     }
     
@@ -117,7 +122,7 @@ int bam_read_idx_get_main(int argc, char** argv)
     char* input_bam = argv[optind++];
     char* readname = argv[optind++];
 
-    bam_read_idx* bri = bam_read_idx_load(input_bam);
+    bam_read_idx* bri = bam_read_idx_load(input_bam, input_bri);
     
     htsFile* bam_fp = hts_open(input_bam, "r");
     bam_hdr_t* h = sam_hdr_read(bam_fp);
@@ -146,4 +151,6 @@ int bam_read_idx_get_main(int argc, char** argv)
     hts_close(bam_fp);
     bam_read_idx_destroy(bri);
     bri = NULL;
+
+    return 0;
 }

--- a/src/bri_index.c
+++ b/src/bri_index.c
@@ -148,7 +148,7 @@ void bam_read_idx_add(bam_read_idx* bri, const char* readname, size_t offset)
     // add readname to collection
     //
     size_t len = strlen(readname) + 1;
-    if(bri->name_count_bytes + len > bri->name_capacity_bytes) {
+    if(bri->name_capacity_bytes <= bri->name_count_bytes + len) {
 
         // if already allocated double size, if initialization start with 1Mb
         bri->name_capacity_bytes = bri->name_capacity_bytes > 0 ? 2 * bri->name_capacity_bytes : 1024*1024;

--- a/src/bri_index.c
+++ b/src/bri_index.c
@@ -19,6 +19,7 @@
 #include "sort_r.h"
 
 //#define BRI_INDEX_DEBUG 1
+char verbose = 0;
 
 // make the index filename based on the name of input_bam
 // caller must free the returned pointer
@@ -127,10 +128,10 @@ void bam_read_idx_save(bam_read_idx* bri, const char* filename)
             disk_offsets_by_record[i] = disk_offsets_by_record[i - 1];
         }
 
-        /*
+#ifdef BRI_INDEX_DEBUG
         fprintf(stderr, "record %zu name: %s redundant: %d do: %zu offset: %zu\n", 
             i, bri->readnames + bri->records[i].read_name.offset, redundant, disk_offsets_by_record[i], bri->records[i].file_offset);
-        */
+#endif
     }
 
     // Pass 2: write the records, getting the read name offset from the disk offset (rather than
@@ -164,7 +165,9 @@ void bam_read_idx_add(bam_read_idx* bri, const char* readname, size_t offset)
 
         // if already allocated double size, if initialization start with 1Mb
         bri->name_capacity_bytes = bri->name_capacity_bytes > 0 ? 2 * bri->name_capacity_bytes : 1024*1024;
-        //fprintf(stderr, "[bri] allocating %zu bytes for names\n", bri->name_capacity_bytes);
+#ifdef BRI_INDEX_DEBUG
+        fprintf(stderr, "[bri] allocating %zu bytes for names\n", bri->name_capacity_bytes);
+#endif
     
         bri->readnames = realloc(bri->readnames, bri->name_capacity_bytes);
         if(bri->readnames == NULL) {
@@ -176,7 +179,7 @@ void bam_read_idx_add(bam_read_idx* bri, const char* readname, size_t offset)
     // in principle this incoming name can be so larger than doubling the size
     // doesn't allow it to fit. This really shouldn't happen so we'll just exit here
     if(bri->name_capacity_bytes <= bri->name_count_bytes + len) {
-        //fprintf(stderr, "[bri] incoming name with length %zu is too large\n", len);
+        fprintf(stderr, "[bri] incoming name with length %zu is too large (%zu %zu)\n", len, bri->name_count_bytes + len, bri->name_capacity_bytes);
         exit(EXIT_FAILURE);
     }
 
@@ -221,13 +224,15 @@ void bam_read_idx_build(const char* filename, const char* output_bri)
     while ((ret = sam_read1(fp, h, b)) >= 0) {
         char* readname = bam_get_qname(b);
         bam_read_idx_add(bri, readname, file_offset);
-        if(bri->record_count % 10000 == 0) {
 
-            bam_read_idx_record brir = bri->records[bri->record_count - 1];
-#ifdef BRI_INDEX_DEBUG
-            fprintf(stderr, "[bri-build] record %zu [%zu %zu] chr: %s:%d read: %s\n", 
-                bri->record_count, brir.read_name.offset, brir.file_offset, h->target_name[b->core.tid], b->core.pos, bri->readnames + brir.read_name.offset);
-#endif
+        bam_read_idx_record brir = bri->records[bri->record_count - 1];
+        if(verbose && (bri->record_count == 1 || bri->record_count % 100000 == 0)) {
+            fprintf(stderr, "[bri-build] record %zu [%zu %zu] %s\n",
+                bri->record_count,
+                brir.read_name.offset,
+                brir.file_offset,
+                bri->readnames + brir.read_name.offset
+            );
         }
 
         // update offset for next record
@@ -239,8 +244,16 @@ void bam_read_idx_build(const char* filename, const char* output_bri)
     hts_close(fp);
 
     // save to disk and cleanup
+    if(verbose) {
+        fprintf(stderr, "[bri-build] writing to disk...\n");
+    }
+
     char* out_fn = generate_index_filename(filename, output_bri);
     bam_read_idx_save(bri, out_fn);
+
+    if(verbose) {
+        fprintf(stderr, "[bri-build] wrote index for %zu records.\n", bri->record_count);
+    }
 
     free(out_fn);
     bam_read_idx_destroy(bri);
@@ -327,10 +340,11 @@ enum {
     OPT_HELP = 1,
 };
 
-static const char* shortopts = ":i:"; // placeholder
+static const char* shortopts = ":i:v"; // placeholder
 static const struct option longopts[] = {
     { "help",                      no_argument,       NULL, OPT_HELP },
     { "index",               required_argument,       NULL,      'i' },
+    { "verbose",                   no_argument,       NULL,      'v' },
     { NULL, 0, NULL, 0 }
 };
 
@@ -353,6 +367,10 @@ int bam_read_idx_index_main(int argc, char** argv)
                 exit(EXIT_SUCCESS);
             case 'i':
                 output_bri = optarg;
+                break;
+            case 'v':
+                verbose = 1;
+                break;
         }
     }
     

--- a/src/bri_index.c
+++ b/src/bri_index.c
@@ -16,6 +16,7 @@
 #include <assert.h>
 #include <getopt.h>
 #include "bri_index.h"
+#include "sort_r.h"
 
 //#define BRI_INDEX_DEBUG 1
 
@@ -79,7 +80,7 @@ void bam_read_idx_save(bam_read_idx* bri, const char* filename)
     FILE* fp = fopen(filename, "wb");
 
     // Sort records by readname
-    qsort_r(bri->records, bri->record_count, sizeof(bam_read_idx_record), compare_records_by_readname_offset, bri->readnames);
+    sort_r(bri->records, bri->record_count, sizeof(bam_read_idx_record), compare_records_by_readname_offset, bri->readnames);
     
     // write header, containing file version, the size (in bytes) of the read names
     // and the number of records. The readnames size is a placeholder and will be

--- a/src/bri_index.h
+++ b/src/bri_index.h
@@ -57,11 +57,11 @@ typedef struct bam_read_idx
 // load the index for input_bam file
 // returns a pointer to the index, which must be deallocated by
 // the caller using bam_read_idx_destroy.
-bam_read_idx* bam_read_idx_load(const char* input_bam);
+bam_read_idx* bam_read_idx_load(const char* input_bam, const char* input_bri);
 
 // construct the index for input_bam and save it to disk
 // to use the created index bam_read_idx_load should be called
-void bam_read_idx_build(const char* input_bam);
+void bam_read_idx_build(const char* input_bam, const char* input_bri);
 
 // cleanup the index by deallocating everything
 void bam_read_idx_destroy(bam_read_idx* bri);

--- a/src/bri_index.h
+++ b/src/bri_index.h
@@ -61,7 +61,7 @@ bam_read_idx* bam_read_idx_load(const char* input_bam, const char* input_bri);
 
 // construct the index for input_bam and save it to disk
 // to use the created index bam_read_idx_load should be called
-void bam_read_idx_build(const char* input_bam, const char* input_bri);
+void bam_read_idx_build(const char* input_bam, const char* output_bri);
 
 // cleanup the index by deallocating everything
 void bam_read_idx_destroy(bam_read_idx* bri);

--- a/src/bri_main.c
+++ b/src/bri_main.c
@@ -11,9 +11,10 @@
 #include <string.h>
 #include "bri_index.h"
 #include "bri_get.h"
+#include "bri_show.h"
 #include "bri_test.h"
 
-#define BRI_VERSION "0.2"
+#define BRI_VERSION "0.3"
 
 void print_version()
 {
@@ -31,6 +32,8 @@ int main(int argc, char** argv)
         bam_read_idx_index_main(argc - 1, argv + 1);
     } else if(strcmp(argv[1], "get") == 0) {
        bam_read_idx_get_main(argc - 1, argv + 1);
+    } else if(strcmp(argv[1], "show") == 0) {
+       bam_read_idx_show_main(argc - 1, argv + 1);
     } else if(strcmp(argv[1], "test") == 0) {
         bam_read_idx_test_main(argc - 1, argv + 1);
     } else if(strcmp(argv[1], "version") == 0) {
@@ -39,5 +42,7 @@ int main(int argc, char** argv)
         fprintf(stderr, "[bri] unrecognized subprogram: %s\n", argv[1]);
         exit(EXIT_FAILURE);
     }
+
+    return 0;
 }
 

--- a/src/bri_show.c
+++ b/src/bri_show.c
@@ -1,0 +1,64 @@
+//---------------------------------------------------------
+// Copyright 2019 Ontario Institute for Cancer Research
+// Written by Jared Simpson (jared.simpson@oicr.on.ca)
+//---------------------------------------------------------
+//
+// bri - simple utility to provide random access to
+//       bam records by read name
+//
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+#include <getopt.h>
+#include "bri_index.h"
+
+//
+// Getopt
+//
+enum {
+    OPT_HELP = 1,
+};
+
+static const char* shortopts = ""; // placeholder
+static const struct option longopts[] = {
+    { "help",                      no_argument,       NULL, OPT_HELP },
+    { NULL, 0, NULL, 0 }
+};
+
+//
+void print_usage_show()
+{
+    fprintf(stderr, "usage: bri show <index_filename.bri>\n");
+}
+
+int bam_read_idx_show_main(int argc, char** argv)
+{
+    int die = 0;
+    for (char c; (c = getopt_long(argc, argv, shortopts, longopts, NULL)) != -1;) {
+        switch (c) {
+            case OPT_HELP:
+                print_usage_show();
+                exit(EXIT_SUCCESS);
+        }
+    }
+    
+    if (argc - optind < 1) {
+        fprintf(stderr, "bri show: not enough arguments\n");
+        die = 1;
+    }
+
+    if(die) {
+        print_usage_show();
+        exit(EXIT_FAILURE);
+    }
+
+    char* input_bri = argv[optind++];
+    bam_read_idx* bri = bam_read_idx_load(NULL, input_bri);
+
+    for(size_t i = 0; i < bri->record_count; ++i) {
+        printf("%s\n", bri->records[i].read_name.ptr);
+    }
+
+    return 0;
+}

--- a/src/bri_show.h
+++ b/src/bri_show.h
@@ -1,0 +1,23 @@
+//---------------------------------------------------------
+// Copyright 2019 Ontario Institute for Cancer Research
+// Written by Jared Simpson (jared.simpson@oicr.on.ca)
+//---------------------------------------------------------
+//
+// bri - simple utility to provide random access to
+//       bam records by read name
+//
+#ifndef BAM_READ_IDX_SHOW
+#define BAM_READ_IDX_SHOW
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+#include <htslib/sam.h>
+#include <htslib/hts.h>
+#include <htslib/bgzf.h>
+
+// main of the "show" subprogram
+int bam_read_idx_show_main(int argc, char** argv);
+
+#endif

--- a/src/bri_test.c
+++ b/src/bri_test.c
@@ -18,7 +18,7 @@ enum {
     OPT_HELP = 1,
 };
 
-static const char* shortopts = ""; // placeholder
+static const char* shortopts = ":i:"; // placeholder
 static const struct option longopts[] = {
     { "help",                      no_argument,       NULL, OPT_HELP },
     { NULL, 0, NULL, 0 }
@@ -26,18 +26,22 @@ static const struct option longopts[] = {
 
 void print_usage_test()
 {
-    fprintf(stderr, "usage: bri test <input.bam>\n");
+    fprintf(stderr, "usage: bri test [-i <index_filename.bri>] <input.bam>\n");
 }
 
 //
 int bam_read_idx_test_main(int argc, char** argv)
 {
+    char* input_bri = NULL;
+
     int die = 0;
     for (char c; (c = getopt_long(argc, argv, shortopts, longopts, NULL)) != -1;) {
         switch (c) {
             case OPT_HELP:
                 print_usage_test();
                 exit(EXIT_SUCCESS);
+            case 'i':
+                input_bri = optarg;
         }
     }
     
@@ -54,7 +58,7 @@ int bam_read_idx_test_main(int argc, char** argv)
     char* input_bam = argv[optind++];
 
     // open files
-    bam_read_idx* bri = bam_read_idx_load(input_bam);
+    bam_read_idx* bri = bam_read_idx_load(input_bam, input_bri);
     htsFile* bam_fp = hts_open(input_bam, "r");
     bam_hdr_t* h = sam_hdr_read(bam_fp);
     bam1_t* b = bam_init1();
@@ -97,4 +101,6 @@ int bam_read_idx_test_main(int argc, char** argv)
     hts_close(bam_fp);
     bam_read_idx_destroy(bri);
     bri = NULL;
+
+    return 0;
 }

--- a/src/sort_r.h
+++ b/src/sort_r.h
@@ -1,0 +1,321 @@
+/* Isaac Turner 29 April 2014 Public Domain */
+#ifndef SORT_R_H_
+#define SORT_R_H_
+
+#include <stdlib.h>
+#include <string.h>
+
+/*
+
+sort_r function to be exported.
+
+Parameters:
+  base is the array to be sorted
+  nel is the number of elements in the array
+  width is the size in bytes of each element of the array
+  compar is the comparison function
+  arg is a pointer to be passed to the comparison function
+
+void sort_r(void *base, size_t nel, size_t width,
+            int (*compar)(const void *_a, const void *_b, void *_arg),
+            void *arg);
+
+*/
+
+#define _SORT_R_INLINE inline
+
+#if (defined __APPLE__ || defined __MACH__ || defined __DARWIN__ || \
+     defined __FreeBSD__ || defined __DragonFly__)
+#  define _SORT_R_BSD
+#elif (defined _GNU_SOURCE || defined __gnu_hurd__ || defined __GNU__ || \
+       defined __linux__ || defined __MINGW32__ || defined __GLIBC__)
+#  define _SORT_R_LINUX
+#elif (defined _WIN32 || defined _WIN64 || defined __WINDOWS__)
+#  define _SORT_R_WINDOWS
+#  undef _SORT_R_INLINE
+#  define _SORT_R_INLINE __inline
+#else
+  /* Using our own recursive quicksort sort_r_simple() */
+#endif
+
+#if (defined NESTED_QSORT && NESTED_QSORT == 0)
+#  undef NESTED_QSORT
+#endif
+
+#define SORT_R_SWAP(a,b,tmp) ((tmp) = (a), (a) = (b), (b) = (tmp))
+
+/* swap a and b */
+/* a and b must not be equal! */
+static _SORT_R_INLINE void sort_r_swap(char *__restrict a, char *__restrict b,
+                                       size_t w)
+{
+  char tmp, *end = a+w;
+  for(; a < end; a++, b++) { SORT_R_SWAP(*a, *b, tmp); }
+}
+
+/* swap a, b iff a>b */
+/* a and b must not be equal! */
+/* __restrict is same as restrict but better support on old machines */
+static _SORT_R_INLINE int sort_r_cmpswap(char *__restrict a,
+                                         char *__restrict b, size_t w,
+                                         int (*compar)(const void *_a,
+                                                       const void *_b,
+                                                       void *_arg),
+                                         void *arg)
+{
+  if(compar(a, b, arg) > 0) {
+    sort_r_swap(a, b, w);
+    return 1;
+  }
+  return 0;
+}
+
+/*
+Swap consecutive blocks of bytes of size na and nb starting at memory addr ptr,
+with the smallest swap so that the blocks are in the opposite order. Blocks may
+be internally re-ordered e.g.
+
+  12345ab  ->   ab34512
+  123abc   ->   abc123
+  12abcde  ->   deabc12
+*/
+static _SORT_R_INLINE void sort_r_swap_blocks(char *ptr, size_t na, size_t nb)
+{
+  if(na > 0 && nb > 0) {
+    if(na > nb) { sort_r_swap(ptr, ptr+na, nb); }
+    else { sort_r_swap(ptr, ptr+nb, na); }
+  }
+}
+
+/* Implement recursive quicksort ourselves */
+/* Note: quicksort is not stable, equivalent values may be swapped */
+static _SORT_R_INLINE void sort_r_simple(void *base, size_t nel, size_t w,
+                                         int (*compar)(const void *_a,
+                                                       const void *_b,
+                                                       void *_arg),
+                                         void *arg)
+{
+  char *b = (char *)base, *end = b + nel*w;
+
+  /* for(size_t i=0; i<nel; i++) {printf("%4i", *(int*)(b + i*sizeof(int)));}
+  printf("\n"); */
+
+  if(nel < 10) {
+    /* Insertion sort for arbitrarily small inputs */
+    char *pi, *pj;
+    for(pi = b+w; pi < end; pi += w) {
+      for(pj = pi; pj > b && sort_r_cmpswap(pj-w,pj,w,compar,arg); pj -= w) {}
+    }
+  }
+  else
+  {
+    /* nel > 6; Quicksort */
+
+    int cmp;
+    char *pl, *ple, *pr, *pre, *pivot;
+    char *last = b+w*(nel-1), *tmp;
+
+    /*
+    Use median of second, middle and second-last items as pivot.
+    First and last may have been swapped with pivot and therefore be extreme
+    */
+    char *l[3];
+    l[0] = b + w;
+    l[1] = b+w*(nel/2);
+    l[2] = last - w;
+
+    /* printf("pivots: %i, %i, %i\n", *(int*)l[0], *(int*)l[1], *(int*)l[2]); */
+
+    if(compar(l[0],l[1],arg) > 0) { SORT_R_SWAP(l[0], l[1], tmp); }
+    if(compar(l[1],l[2],arg) > 0) {
+      SORT_R_SWAP(l[1], l[2], tmp);
+      if(compar(l[0],l[1],arg) > 0) { SORT_R_SWAP(l[0], l[1], tmp); }
+    }
+
+    /* swap mid value (l[1]), and last element to put pivot as last element */
+    if(l[1] != last) { sort_r_swap(l[1], last, w); }
+
+    /*
+    pl is the next item on the left to be compared to the pivot
+    pr is the last item on the right that was compared to the pivot
+    ple is the left position to put the next item that equals the pivot
+    ple is the last right position where we put an item that equals the pivot
+
+                                           v- end (beyond the array)
+      EEEEEELLLLLLLLuuuuuuuuGGGGGGGEEEEEEEE.
+      ^- b  ^- ple  ^- pl   ^- pr  ^- pre ^- last (where the pivot is)
+
+    Pivot comparison key:
+      E = equal, L = less than, u = unknown, G = greater than, E = equal
+    */
+    pivot = last;
+    ple = pl = b;
+    pre = pr = last;
+
+    /*
+    Strategy:
+    Loop into the list from the left and right at the same time to find:
+    - an item on the left that is greater than the pivot
+    - an item on the right that is less than the pivot
+    Once found, they are swapped and the loop continues.
+    Meanwhile items that are equal to the pivot are moved to the edges of the
+    array.
+    */
+    while(pl < pr) {
+      /* Move left hand items which are equal to the pivot to the far left.
+         break when we find an item that is greater than the pivot */
+      for(; pl < pr; pl += w) {
+        cmp = compar(pl, pivot, arg);
+        if(cmp > 0) { break; }
+        else if(cmp == 0) {
+          if(ple < pl) { sort_r_swap(ple, pl, w); }
+          ple += w;
+        }
+      }
+      /* break if last batch of left hand items were equal to pivot */
+      if(pl >= pr) { break; }
+      /* Move right hand items which are equal to the pivot to the far right.
+         break when we find an item that is less than the pivot */
+      for(; pl < pr; ) {
+        pr -= w; /* Move right pointer onto an unprocessed item */
+        cmp = compar(pr, pivot, arg);
+        if(cmp == 0) {
+          pre -= w;
+          if(pr < pre) { sort_r_swap(pr, pre, w); }
+        }
+        else if(cmp < 0) {
+          if(pl < pr) { sort_r_swap(pl, pr, w); }
+          pl += w;
+          break;
+        }
+      }
+    }
+
+    pl = pr; /* pr may have gone below pl */
+
+    /*
+    Now we need to go from: EEELLLGGGGEEEE
+                        to: LLLEEEEEEEGGGG
+
+    Pivot comparison key:
+      E = equal, L = less than, u = unknown, G = greater than, E = equal
+    */
+    sort_r_swap_blocks(b, ple-b, pl-ple);
+    sort_r_swap_blocks(pr, pre-pr, end-pre);
+
+    /*for(size_t i=0; i<nel; i++) {printf("%4i", *(int*)(b + i*sizeof(int)));}
+    printf("\n");*/
+
+    sort_r_simple(b, (pl-ple)/w, w, compar, arg);
+    sort_r_simple(end-(pre-pr), (pre-pr)/w, w, compar, arg);
+  }
+}
+
+
+#if defined NESTED_QSORT
+
+  static _SORT_R_INLINE void sort_r(void *base, size_t nel, size_t width,
+                                    int (*compar)(const void *_a,
+                                                  const void *_b,
+                                                  void *aarg),
+                                    void *arg)
+  {
+    int nested_cmp(const void *a, const void *b)
+    {
+      return compar(a, b, arg);
+    }
+
+    qsort(base, nel, width, nested_cmp);
+  }
+
+#else /* !NESTED_QSORT */
+
+  /* Declare structs and functions */
+
+  #if defined _SORT_R_BSD
+
+    /* Ensure qsort_r is defined */
+    extern void qsort_r(void *base, size_t nel, size_t width, void *thunk,
+                        int (*compar)(void *_thunk,
+                                      const void *_a, const void *_b));
+
+  #endif
+
+  #if defined _SORT_R_BSD || defined _SORT_R_WINDOWS
+
+    /* BSD (qsort_r), Windows (qsort_s) require argument swap */
+
+    struct sort_r_data
+    {
+      void *arg;
+      int (*compar)(const void *_a, const void *_b, void *_arg);
+    };
+
+    static _SORT_R_INLINE int sort_r_arg_swap(void *s,
+                                              const void *a, const void *b)
+    {
+      struct sort_r_data *ss = (struct sort_r_data*)s;
+      return (ss->compar)(a, b, ss->arg);
+    }
+
+  #endif
+
+  #if defined _SORT_R_LINUX
+
+    typedef int(* __compar_d_fn_t)(const void *, const void *, void *);
+    extern void qsort_r(void *base, size_t nel, size_t width,
+                        __compar_d_fn_t __compar, void *arg)
+      __attribute__((nonnull (1, 4)));
+
+  #endif
+
+  /* implementation */
+
+  static _SORT_R_INLINE void sort_r(void *base, size_t nel, size_t width,
+                                    int (*compar)(const void *_a,
+                                                  const void *_b, void *_arg),
+                                    void *arg)
+  {
+    #if defined _SORT_R_LINUX
+
+      #if defined __GLIBC__ && ((__GLIBC__ < 2) || (__GLIBC__ == 2 && __GLIBC_MINOR__ < 8))
+
+        /* no qsort_r in glibc before 2.8, need to use nested qsort */
+        sort_r_simple(base, nel, width, compar, arg);
+
+      #else
+
+        qsort_r(base, nel, width, compar, arg);
+
+      #endif
+
+    #elif defined _SORT_R_BSD
+
+      struct sort_r_data tmp;
+      tmp.arg = arg;
+      tmp.compar = compar;
+      qsort_r(base, nel, width, &tmp, sort_r_arg_swap);
+
+    #elif defined _SORT_R_WINDOWS
+
+      struct sort_r_data tmp;
+      tmp.arg = arg;
+      tmp.compar = compar;
+      qsort_s(base, nel, width, sort_r_arg_swap, &tmp);
+
+    #else
+
+      /* Fall back to our own quicksort implementation */
+      sort_r_simple(base, nel, width, compar, arg);
+
+    #endif
+  }
+
+#endif /* !NESTED_QSORT */
+
+#undef _SORT_R_INLINE
+#undef _SORT_R_WINDOWS
+#undef _SORT_R_LINUX
+#undef _SORT_R_BSD
+
+#endif /* SORT_R_H_ */


### PR DESCRIPTION
Allow multiple reads be fetched from a single invocation of the get
subcommand.

Added new subcommand "show", which lists the contents of an index.  This
is useful when formulating a scatter-gather plan to process pieces of a
BAM file in parallel, and is much faster than fetching the equivalent
information from the BAM file itself.

Added a verbosity ("-v") flag to the index subcommand, enabling progress
monitoring for long-running index commands.