### PR TITLE
Draft: Add htslib thread pool to build. Add partial index

### DIFF
--- a/src/bri_index.h
+++ b/src/bri_index.h
@@ -15,6 +15,7 @@
 #include <assert.h>
 #include <htslib/sam.h>
 #include <htslib/hts.h>
+#include <htslib/thread_pool.h>
 #include <htslib/bgzf.h>
 
 // An entry record in the index, storing
@@ -61,7 +62,7 @@ bam_read_idx* bam_read_idx_load(const char* input_bam, const char* input_bri);
 
 // construct the index for input_bam and save it to disk
 // to use the created index bam_read_idx_load should be called
-void bam_read_idx_build(const char* input_bam, const char* output_bri);
+void bam_read_idx_build(const char* input_bam, const char* output_bri, int threads, int every);
 
 // cleanup the index by deallocating everything
 void bam_read_idx_destroy(bam_read_idx* bri);


### PR DESCRIPTION
* Add a thread pool to speed up bam decompression during index build. I've tested that the index is unaffected by this; though I don't understand htslib enough to know how the `bgzf_tell()` call is unaffected by this.
* Add an `--every=N` option to `bri index` to build a partial index. The use case here is to be able to load N reads from a bam in a workflow parallelised into chunks of an unsorted (or name-sorted) BAM. I haven't considered how this works in the case of multiple alignment records for a query.

Benchmarking threads:
```
$ time ./bri index -i /scratch/cwright/test.unaligned.bam.bri  test.unaligned.bam

real	35m23.072s
user	34m37.240s
sys	0m44.307s

$ time ./bri index -t 3 -i /scratch/cwright/test.unaligned.bam.bri  test.unaligned.bam
[bri-build] writing to disk...
[bri-build] wrote index for 31582413 records.

real	13m58.457s
user	39m23.216s
sys	5m44.936s
```